### PR TITLE
Fix command to add natnetwork

### DIFF
--- a/src/github.com/cppforlife/bosh-virtualbox-cpi/vm/nics.go
+++ b/src/github.com/cppforlife/bosh-virtualbox-cpi/vm/nics.go
@@ -55,7 +55,7 @@ func (n NICs) addNIC(nic string, net Network) (string, error) {
 	case "nat":
 		args = append(args, []string{"nat"}...)
 	case "natnetwork":
-		args = append(args, []string{"natnetwork", "--natnet" + nic, net.CloudPropertyName}...)
+		args = append(args, []string{"natnetwork", "--nat-network" + nic, net.CloudPropertyName}...)
 	case "hostonly":
 		args = append(args, []string{"hostonly", "--hostonlyadapter" + nic, net.CloudPropertyName}...)
 	default:


### PR DESCRIPTION
https://www.virtualbox.org/manual/ch08.html says that `--natnet` is for the `nat` network type, not `natnetwork`.

Signed-off-by: Emily Casey <ecasey@pivotal.io>