### PR TITLE
keep host only setting consistent

### DIFF
--- a/docs/networks-host-only.md
+++ b/docs/networks-host-only.md
@@ -16,8 +16,8 @@ $ ifconfig
 _...other entries..._
 vboxnet0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500
 	ether 0a:00:27:00:00:00
-	inet 192.168.56.1 netmask 0xffffff00 broadcast 192.168.56.255
+	inet 192.168.50.1 netmask 0xffffff00 broadcast 192.168.50.255
 
 ```
 
-Finally, make sure you can ping the IP address `192.168.56.1`.
+Finally, make sure you can ping the IP address `192.168.50.1`.


### PR DESCRIPTION
I was following this https://github.com/cloudfoundry/bosh-deployment/blob/master/docs/bosh-lite-on-vbox.md to deploy bosh-lite on Virtual Box. I tried to `ping 192.168.56.1` and it timed out. I checked my HostOnly networking setting and can not figure out why it timed out. Finally I noticed that the Ip is not consist, I suppose to `ping 192.168.50.1` to verify.