### PR TITLE
enable usage of known bridged networks; fix regression with remote host SSH

### DIFF
--- a/src/github.com/cppforlife/bosh-virtualbox-cpi/driver/ssh_runner.go
+++ b/src/github.com/cppforlife/bosh-virtualbox-cpi/driver/ssh_runner.go
@@ -166,8 +166,9 @@ func (r *SSHRunner) client() (*ssh.Client, error) {
 	}
 
 	config := &ssh.ClientConfig{
-		User: r.opts.Username,
-		Auth: []ssh.AuthMethod{ssh.PublicKeys(keySigner)},
+		User:            r.opts.Username,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(keySigner)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
 	r.existingClient, err = ssh.Dial("tcp", fmt.Sprintf("%s:22", r.opts.Host), config)

--- a/src/github.com/cppforlife/bosh-virtualbox-cpi/driver/ssh_runner_test.go
+++ b/src/github.com/cppforlife/bosh-virtualbox-cpi/driver/ssh_runner_test.go
@@ -13,6 +13,7 @@ import (
 var (
 	testSSHRunnerUsername   = os.Getenv("TEST_SSH_RUNNER_USERNAME")
 	testSSHRunnerPrivateKey = os.Getenv("TEST_SSH_RUNNER_PRIVATE_KEY")
+	testSSHRunnerHost       = os.Getenv("TEST_SSH_RUNNER_HOST")
 )
 
 var _ = Describe("SSHRunner", func() {
@@ -20,12 +21,15 @@ var _ = Describe("SSHRunner", func() {
 		if len(testSSHRunnerUsername) == 0 {
 			Skip("SSHRunner tests are not configured")
 		}
+		if testSSHRunnerHost == "" {
+			testSSHRunnerHost = "127.0.0.1"
+		}
 	})
 
 	Describe("HomeDir", func() {
 		It("returns proper home directory", func() {
 			opts := SSHRunnerOpts{
-				Host:       "127.0.0.1",
+				Host:       testSSHRunnerHost,
 				Username:   testSSHRunnerUsername,
 				PrivateKey: testSSHRunnerPrivateKey,
 			}

--- a/src/github.com/cppforlife/bosh-virtualbox-cpi/vm/host.go
+++ b/src/github.com/cppforlife/bosh-virtualbox-cpi/vm/host.go
@@ -22,6 +22,9 @@ func (h Host) FindNetwork(net Network) (bnet.Network, error) {
 	case bnet.HostOnlyType:
 		return newHostNetwork(net, hostOnlysAdapter{h.networks}).Find()
 
+	case bnet.BridgedType:
+		return newHostNetwork(net, bridgedNetworksAdapter{h.networks}).Find()
+
 	default:
 		return nil, fmt.Errorf("Unknown network type: %s", net.CloudPropertyType())
 	}
@@ -193,6 +196,29 @@ func (n hostOnlysAdapter) Create(net Network) error {
 }
 
 func (n hostOnlysAdapter) Matches(net Network, actualNet bnet.Network) bool {
+	if len(net.CloudPropertyName()) > 0 {
+		return net.CloudPropertyName() == actualNet.Name()
+	}
+
+	actualIP := gonet.IP(actualNet.IPNet().IP).String()
+	actualNetmask := gonet.IP(actualNet.IPNet().Mask).String()
+
+	return actualNetmask == net.Netmask() && actualIP == net.Gateway()
+}
+
+type bridgedNetworksAdapter struct {
+	bnet.Networks
+}
+
+func (n bridgedNetworksAdapter) List() ([]bnet.Network, error) {
+	return n.BridgedNetworks()
+}
+
+func (n bridgedNetworksAdapter) Create(net Network) error {
+	return fmt.Errorf("Expected to find bridged network '%s'", net.CloudPropertyName())
+}
+
+func (n bridgedNetworksAdapter) Matches(net Network, actualNet bnet.Network) bool {
 	if len(net.CloudPropertyName()) > 0 {
 		return net.CloudPropertyName() == actualNet.Name()
 	}

--- a/src/github.com/cppforlife/bosh-virtualbox-cpi/vm/network/networks.go
+++ b/src/github.com/cppforlife/bosh-virtualbox-cpi/vm/network/networks.go
@@ -92,6 +92,58 @@ func (n Networks) NATNetworks() ([]Network, error) {
 	return nets, nil
 }
 
+func (n Networks) BridgedNetworks() ([]Network, error) {
+	output, err := n.driver.Execute("list", "bridgedifs")
+	if err != nil {
+		return nil, err
+	}
+
+	var nets []Network
+
+	for _, netChunk := range n.outputChunks(output) {
+		// TODO : this is semantically incorrect but behavior is the same
+		// because we never call mutating methods on the HostOnly when we
+		// have the bridgedNetworkAdapter
+		net := HostOnly{driver: n.driver}
+
+		for _, line := range strings.Split(netChunk, "\n") {
+			matches := netKVMatch.FindStringSubmatch(line)
+			if len(matches) != 3 {
+				panic(fmt.Sprintf("Internal inconsistency: Expected len(%s matches) == 3: line '%s'", netKVMatch, line))
+			}
+
+			var err error
+
+			switch matches[1] {
+			// does not include all keys
+			case "Name":
+				net.name = matches[2]
+			case "DHCP":
+				net.dhcp, err = n.toBool(matches[2])
+			case "IPAddress":
+				net.ipAddress = matches[2]
+			case "NetworkMask":
+				net.networkMask = matches[2]
+			case "Status":
+				net.status = matches[2]
+			}
+
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		err := (&net).populateIPNet()
+		if err != nil {
+			return nil, err
+		}
+
+		nets = append(nets, net)
+	}
+
+	return nets, nil
+}
+
 func (n Networks) HostOnlys() ([]Network, error) {
 	output, err := n.driver.Execute("list", "hostonlyifs")
 	if err != nil {

--- a/src/github.com/cppforlife/bosh-virtualbox-cpi/vm/nics.go
+++ b/src/github.com/cppforlife/bosh-virtualbox-cpi/vm/nics.go
@@ -68,6 +68,13 @@ func (n NICs) addNIC(nic string, net Network, host Host) (string, error) {
 		}
 		args = append(args, []string{"hostonly", "--hostonlyadapter" + nic, actualNet.Name()}...)
 
+	case bnet.BridgedType:
+		actualNet, err := host.FindNetwork(net)
+		if err != nil {
+			return "", err
+		}
+		args = append(args, []string{"bridged", "--bridgeadapter" + nic, actualNet.Name()}...)
+
 	default:
 		return "", bosherr.Errorf("Unknown network type: %s", net.CloudPropertyType())
 	}


### PR DESCRIPTION
1. bridged networks

- you had a WIP branch on this topic which I have progressed further. it is working for me but may not be complete; please give feedback at your convenience.
- right now, you cannot enable or create bridged networks -- so it is only useful in cases where the bridged interface already exists.

2. ssh host key checking

see commit message for details, but there was a regression in golang which prevented a fail-open behavior when checking host public key. the code i have put in is backwards-compatible (same insecure behavior as before) but now the SSH feature of this CPI will at least work as before. more work / configuration options would be required to do better security checking.

this regression was not caught because the test is skipped if you don't set env variable in this codebase. you see that it does indeed fail with old code if you configure it properly. i have updated the test for more flexibility as well.